### PR TITLE
Feature/auth/history

### DIFF
--- a/src/_common/pagination/pagination.interface.ts
+++ b/src/_common/pagination/pagination.interface.ts
@@ -1,0 +1,8 @@
+export interface IMetaData {
+  meta: {
+    currentPage: number;
+    maxPage: number;
+    allCount: number;
+    take: number;
+  };
+}

--- a/src/_common/pagination/pagination.module.ts
+++ b/src/_common/pagination/pagination.module.ts
@@ -1,0 +1,8 @@
+import { Global, Module } from '@nestjs/common';
+import { PaginationService } from './pagination.service';
+
+@Global()
+@Module({
+  providers: [PaginationService],
+})
+export class PaginationModule {}

--- a/src/_common/pagination/pagination.service.ts
+++ b/src/_common/pagination/pagination.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { IPagination } from '../_utils/interfaces/request.interface';
+
+@Injectable()
+export class PaginationService {
+  meta(allCount: number, data: IPagination) {
+    return { meta: { currentPage: data.page, maxPage: Math.ceil(allCount / data.take), allCount, take: data.take } };
+  }
+}

--- a/src/_common/pagination/pagination.service.ts
+++ b/src/_common/pagination/pagination.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { IPagination } from '../_utils/interfaces/request.interface';
+import { IMetaData } from './pagination.interface';
 
 @Injectable()
 export class PaginationService {
-  metaData(allCount: number, data: IPagination) {
+  metaData(allCount: number, data: IPagination): IMetaData {
     return { meta: { currentPage: data.page, maxPage: Math.ceil(allCount / data.take), allCount, take: data.take } };
   }
 }

--- a/src/_common/pagination/pagination.service.ts
+++ b/src/_common/pagination/pagination.service.ts
@@ -3,7 +3,7 @@ import { IPagination } from '../_utils/interfaces/request.interface';
 
 @Injectable()
 export class PaginationService {
-  meta(allCount: number, data: IPagination) {
+  metaData(allCount: number, data: IPagination) {
     return { meta: { currentPage: data.page, maxPage: Math.ceil(allCount / data.take), allCount, take: data.take } };
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { AuthModule } from './auth/auth.module';
 import { BanedMemberModule } from './member/baned-member/baned-member.module';
 import { AuthHistoryModule } from './auth/auth-history/auth-history.module';
 import { BlogModule } from './blog/blog.module';
+import { PaginationModule } from './_common/pagination/pagination.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { BlogModule } from './blog/blog.module';
     AuthModule,
     BanedMemberModule,
     AuthHistoryModule,
+    PaginationModule,
   ],
   controllers: [],
   providers: [],

--- a/src/auth/auth-history/auth-history.repository.ts
+++ b/src/auth/auth-history/auth-history.repository.ts
@@ -1,10 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../_common/prisma/prisma.service';
 import { Prisma } from '@prisma/client';
+import { IPaginationAuthHistory } from './auth-history.interface';
+import { PaginationService } from '../../_common/pagination/pagination.service';
 
 @Injectable()
 export class AuthHistoryRepository {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private paginationService: PaginationService,
+  ) {}
 
   private authHistoryRepository = this.prisma.extendedClient.authHistory;
 
@@ -16,7 +21,10 @@ export class AuthHistoryRepository {
     return this.authHistoryRepository.createMany({ data });
   }
 
-  async findManyAndCount(options: Prisma.AuthHistoryFindManyArgs) {
-    return this.prisma.$transaction([this.authHistoryRepository.findMany(options), this.authHistoryRepository.count({ where: options.where })]);
+  async findManyAndCount(memberId: string, data: IPaginationAuthHistory) {
+    //select은 options 변수가 아닌 메소드에 직접 설정하세요.
+    const options: Prisma.AuthHistoryFindManyArgs = { where: { ...(memberId && {}) }, take: data.take, skip: (data.page - 1) * data.take };
+    const [result, allCount] = await this.prisma.$transaction([this.authHistoryRepository.findMany(options), this.authHistoryRepository.count({ where: options.where })]);
+    return [result, this.paginationService.metaData(allCount, data)];
   }
 }

--- a/src/auth/auth-history/auth-history.service.ts
+++ b/src/auth/auth-history/auth-history.service.ts
@@ -27,8 +27,6 @@ export class AuthHistoryService {
   }
 
   async findManyAndCount(memberId: string, data: IPaginationAuthHistory) {
-    //타입별로 결과를 반환하는 필터기능이 추가됐으면해 searchType: number
-    const options: Prisma.AuthHistoryFindManyArgs = { where: { memberId }, take: data.take, skip: (data.page - 1) * data.take };
-    return await this.authHistoryRepository.findManyAndCount(options);
+    return await this.authHistoryRepository.findManyAndCount(memberId, data);
   }
 }


### PR DESCRIPTION

## Pagination Module
1. 모든 모듈에서 공통으로 metaData를 반환할 수 있도록 metaData메소드 생성
2. 전역으로 사용할 모듈임으로 글로벌 모듈 설정 @Global()


## auth-history/findManyAndCount
1. ORM 옵션을 서비스 레이어에서 가공하여 전달하였으나 레이어 규정에 맞지 않음으로 repository 레이어로 이동
2. pagination Service를 활용하여 metadata를 생성하여 반환


## QA
1. metaData 메소드 하나만 생성하여 관리할 예정인데, 굳이 모듈화를 했어야 했나?
(위 경우 함수로 변경하게되면 OOP 프로그래밍 방식에 문제가 발생하지 않는가?)


QA결과에 따라 함수로 관리할지, 모듈을 관리할지 결정