### PR TITLE
tag API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { BanedMemberModule } from './member/baned-member/baned-member.module';
 import { AuthHistoryModule } from './auth/auth-history/auth-history.module';
 import { BlogModule } from './blog/blog.module';
 import { PaginationModule } from './_common/pagination/pagination.module';
+import { TagModule } from './blog/tag/tag.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { PaginationModule } from './_common/pagination/pagination.module';
     BanedMemberModule,
     AuthHistoryModule,
     PaginationModule,
+    TagModule,
   ],
   controllers: [],
   providers: [],

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -1,10 +1,13 @@
-import { Body, Controller, Delete, Param, Patch, Post, Get, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Param, Patch, Post, Get, Query, UseGuards, Put } from '@nestjs/common';
 import { BlogService } from './blog.service';
 import { BlogAddressDto, BlogIdDto, CreateBlogDto, PaginationBlogDto, UpdateBlogDto } from './blog.dto';
 import { Blog } from '@prisma/client';
 import { Member } from '../_common/_utils/decorators/member.decorator';
 import { IPayload } from '../_common/jwt/jwt.interface';
 import { UserAuthGuard } from '../_common/_utils/guards/user.auth.guard';
+import { TagCreateDto } from './tag/dtos/create/request.dto';
+import { BlogAndTagParamDto, BlogParamDto } from './dtos/param.request.dto';
+import { TagUpdateDto } from './tag/dtos/update/request.dto';
 
 /**
  * Blog 관련 요청을 처리하는 Controller Class
@@ -50,5 +53,23 @@ export class BlogController {
   @UseGuards(UserAuthGuard)
   async delete(@Member() member: IPayload, @Param() param: BlogIdDto): Promise<string> {
     return await this.blogService.softDelete(param.id, member.id);
+  }
+
+  @Post(':id/tags')
+  @UseGuards(UserAuthGuard)
+  async tagCreate(@Member() member: IPayload, @Body() body: TagCreateDto, @Param() { id }: BlogParamDto): Promise<string> {
+    return await this.blogService.tagCreate(id, member.id, body);
+  }
+
+  @Put(':id/tags/:tagId')
+  @UseGuards(UserAuthGuard)
+  async tagUpdate(@Member() member: IPayload, @Body() body: TagUpdateDto, @Param() { id, tagId }: BlogAndTagParamDto): Promise<string> {
+    return await this.blogService.tagUpdate(id, member.id, tagId, body);
+  }
+
+  @Delete(':id/tags/:tagId')
+  @UseGuards(UserAuthGuard)
+  async tagSoftDelete(@Member() member: IPayload, @Param() { id, tagId }: BlogAndTagParamDto): Promise<string> {
+    return await this.blogService.tagSoftDelete(id, member.id, tagId);
   }
 }

--- a/src/blog/blog.module.ts
+++ b/src/blog/blog.module.ts
@@ -4,9 +4,10 @@ import { BlogService } from './blog.service';
 import { MemberModule } from '../member/member.module';
 import { BlogRepository } from './blog.repository';
 import { PrismaModule } from '../_common/prisma/prisma.module';
+import { TagModule } from './tag/tag.module';
 
 @Module({
-  imports: [MemberModule, PrismaModule],
+  imports: [MemberModule, PrismaModule, TagModule],
   controllers: [BlogController],
   providers: [BlogService, BlogRepository],
 })

--- a/src/blog/blog.repository.ts
+++ b/src/blog/blog.repository.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../_common/prisma/prisma.service';
 import { Blog, Prisma } from '@prisma/client';
 
@@ -42,5 +42,11 @@ export class BlogRepository {
   /* 블로그 ID 찾기 */
   async findUnique(id: number): Promise<Blog | null> {
     return this.blogRepository.findFirst({ where: { id } });
+  }
+
+  async findUniqueOrThrow(id: number): Promise<Blog> {
+    const blog = await this.blogRepository.findUnique({ where: { id } });
+    if (!blog) throw new NotFoundException('해당하는 블로그가 존재하지 않습니다.');
+    return blog;
   }
 }

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -28,7 +28,7 @@ export class BlogService {
   /* 블로그 수정 */
   async update(id: number, memberId: string, data: IUpdateBlog): Promise<string> {
     await this.memberService.findUniqueOrThrow(memberId);
-    const blog = await this.findUniqueOrThrow(id);
+    const blog = await this.blogRepository.findUniqueOrThrow(id);
     await this.verifyAccessAuthorityOrThrow(blog.memberId, memberId);
     if (data.address) await this.isExistByAddress(data.address);
     await this.blogRepository.update(id, data);
@@ -38,7 +38,7 @@ export class BlogService {
 
   /* 블로그 아이디별 조회 */
   async findUnique(id: number): Promise<Blog> {
-    return await this.findUniqueOrThrow(id);
+    return await this.blogRepository.findUniqueOrThrow(id);
   }
 
   /* 블로그 주소별 조회 */
@@ -50,7 +50,7 @@ export class BlogService {
   /* 블로그 삭제 */
   async softDelete(id: number, memberId: string): Promise<string> {
     await this.memberService.findUniqueOrThrow(memberId);
-    const blog = await this.findUniqueOrThrow(id);
+    const blog = await this.blogRepository.findUniqueOrThrow(id);
     await this.verifyAccessAuthorityOrThrow(blog.memberId, memberId);
     await this.blogRepository.softDelete(id);
     return '선택하신 블로그를 삭제하였습니다.';

--- a/src/blog/dtos/param.request.dto.ts
+++ b/src/blog/dtos/param.request.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsNumber } from '@inhanbyeol/class-validator';
+
+export class BlogParamDto {
+  @IsNotEmpty()
+  @IsNumber()
+  id: number;
+}
+
+export class BlogAndTagParamDto extends BlogParamDto {
+  @IsNotEmpty()
+  @IsNumber()
+  tagId: number;
+}

--- a/src/blog/tag/dtos/create/request.dto.ts
+++ b/src/blog/tag/dtos/create/request.dto.ts
@@ -1,0 +1,12 @@
+import { Prisma } from '@prisma/client';
+import { IsNotEmpty, IsNumber, IsString } from '@inhanbyeol/class-validator';
+
+export class TagCreateDto implements Prisma.TagUncheckedCreateInput {
+  @IsNotEmpty()
+  @IsString()
+  name: string;
+
+  @IsNotEmpty()
+  @IsNumber()
+  blogId: number;
+}

--- a/src/blog/tag/dtos/update/request.dto.ts
+++ b/src/blog/tag/dtos/update/request.dto.ts
@@ -1,0 +1,8 @@
+import { Prisma } from '@prisma/client';
+import { IsNotEmpty, IsString } from '@inhanbyeol/class-validator';
+
+export class TagUpdateDto implements Prisma.TagUpdateInput {
+  @IsNotEmpty()
+  @IsString()
+  name: string;
+}

--- a/src/blog/tag/tag.module.ts
+++ b/src/blog/tag/tag.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TagService } from './tag.service';
+import { TagRepository } from './tag.repository';
+
+@Module({
+  providers: [TagService, TagRepository],
+  exports: [TagService],
+})
+export class TagModule {}

--- a/src/blog/tag/tag.repository.ts
+++ b/src/blog/tag/tag.repository.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../_common/prisma/prisma.service';
+
+@Injectable()
+export class TagRepository {
+  constructor(private prisma: PrismaService) {}
+
+  private tagRepository = this.prisma.extendedClient.tag;
+}

--- a/src/blog/tag/tag.repository.ts
+++ b/src/blog/tag/tag.repository.ts
@@ -8,7 +8,7 @@ export class TagRepository {
 
   private tagRepository = this.prisma.extendedClient.tag;
 
-  async create(data: Prisma.TagCreateInput): Promise<Tag> {
+  async create(data: Prisma.TagUncheckedCreateInput): Promise<Tag> {
     return this.tagRepository.create({ data });
   }
 

--- a/src/blog/tag/tag.repository.ts
+++ b/src/blog/tag/tag.repository.ts
@@ -1,9 +1,28 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../_common/prisma/prisma.service';
+import { Prisma, Tag } from '@prisma/client';
 
 @Injectable()
 export class TagRepository {
   constructor(private prisma: PrismaService) {}
 
   private tagRepository = this.prisma.extendedClient.tag;
+
+  async create(data: Prisma.TagCreateInput): Promise<Tag> {
+    return this.tagRepository.create({ data });
+  }
+
+  async update(id: number, data: Prisma.TagUpdateInput): Promise<Tag> {
+    return this.tagRepository.update({ where: { id }, data });
+  }
+
+  async softDelete(id: number): Promise<void> {
+    await this.tagRepository.softDelete({ id });
+  }
+
+  async findUniqueOrThrow(id: number): Promise<Tag> {
+    const tag = await this.tagRepository.findUnique({ where: { id } });
+    if (!tag) throw new NotFoundException('존재하지 않는 리소스입니다.');
+    return tag;
+  }
 }

--- a/src/blog/tag/tag.service.ts
+++ b/src/blog/tag/tag.service.ts
@@ -6,7 +6,7 @@ import { Prisma, Tag } from '@prisma/client';
 export class TagService {
   constructor(private tagRepository: TagRepository) {}
 
-  async create(data: Prisma.TagCreateInput): Promise<Tag> {
+  async create(data: Prisma.TagUncheckedCreateInput): Promise<Tag> {
     return await this.tagRepository.create(data);
   }
 

--- a/src/blog/tag/tag.service.ts
+++ b/src/blog/tag/tag.service.ts
@@ -1,7 +1,26 @@
 import { Injectable } from '@nestjs/common';
 import { TagRepository } from './tag.repository';
+import { Prisma, Tag } from '@prisma/client';
 
 @Injectable()
 export class TagService {
   constructor(private tagRepository: TagRepository) {}
+
+  async create(data: Prisma.TagCreateInput): Promise<Tag> {
+    return await this.tagRepository.create(data);
+  }
+
+  async update(id: number, data: Prisma.TagUpdateInput): Promise<Tag> {
+    await this.tagRepository.findUniqueOrThrow(id);
+    return await this.tagRepository.update(id, data);
+  }
+
+  async softDelete(id: number): Promise<void> {
+    await this.tagRepository.findUniqueOrThrow(id);
+    return await this.tagRepository.softDelete(id);
+  }
+
+  async findUnique(id: number): Promise<Tag> {
+    return await this.tagRepository.findUniqueOrThrow(id);
+  }
 }

--- a/src/blog/tag/tag.service.ts
+++ b/src/blog/tag/tag.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { TagRepository } from './tag.repository';
+
+@Injectable()
+export class TagService {
+  constructor(private tagRepository: TagRepository) {}
+}


### PR DESCRIPTION
### blog Service

- findUniqueOrThrow 레이어 위치 이동 (service -> repository)
- 기존 service의 findUniqueOrThrow 사용하던 로직들 repository 레이어에 이동한 메소드로 변경

### tag Service

> 모든 태그 서비스는 블로그 하위 요소로 'blog controller' 에서 api 생성

- 생성
- 수정
- 삭제